### PR TITLE
Remove requirements files and use pyproject.toml with uv

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: |
           source .venv/bin/activate
-          uv pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt
+          uv pip install .[dev]
 
       - name: Run tests
         env:
@@ -60,7 +60,7 @@ jobs:
           COVERAGE_FILE: ${{ github.workspace }}/.coverage
         run: |
           source .venv/bin/activate
-          pytest --cov=showstock --cov-report=term --cov-report=xml:coverage.xml
+          pytest
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,0 @@
-pytest>=7.3.1
-pytest-cov>=4.1.0
-black>=23.3.0
-isort>=5.12.0
-flake8>=6.0.0
-mypy>=1.3.0
-httpx>=0.24.0  # Required for FastAPI TestClient
-pre-commit>=3.3.1
-pytest-asyncio>=0.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-fastapi>=0.95.0
-uvicorn>=0.21.1
-sqlalchemy>=2.0.0
-psycopg2-binary>=2.9.5
-pydantic>=2.0.0
-pydantic-settings>=2.0.0
-alembic>=1.10.0
-asyncpg>=0.27.0
-python-dotenv>=1.0.0


### PR DESCRIPTION
This PR removes the requirements.txt and requirements-dev.txt files in favor of using pyproject.toml with uv for dependency management. The GitHub Actions workflow has been updated accordingly.