### PR TITLE
Close db generator in tests

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -109,6 +109,7 @@ async def test_get_db(mock_session_factory):
     # Use the generator
     db_gen = get_db()
     session = await anext(db_gen)
+    await db_gen.aclose()
 
     # Verify we got the session
     assert session == mock_session


### PR DESCRIPTION
## Summary
- close get_db generator after using it in `test_get_db`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866fee4bd98832693ce2d7645a217dc