### PR TITLE
Add MkDocs docs site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,45 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs mkdocs-material
+      - name: Build site
+        run: mkdocs build -d site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,13 @@
+# Showstock
+
+Showstock is a nutrition management system for show livestock built with FastAPI.
+
+## Features
+
+- FastAPI web application
+- SQLAlchemy ORM with async support
+- PostgreSQL database with connection pooling
+- Environment-based configuration
+- Fast package management with [uv](https://github.com/astral-sh/uv)
+
+For development instructions see the project's README.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,10 @@
+site_name: Showstock
+site_description: Nutrition management for show livestock
+docs_dir: docs
+theme:
+  name: material
+nav:
+  - Home: index.md
+  - Codex:
+      - "AppConfig Usage": codex/app_config_usage.md
+      - "Database Connection": codex/database.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,10 @@ dev = [
     "pre-commit>=3.3.1",
     "pytest-asyncio>=0.23.0",
 ]
+docs = [
+    "mkdocs>=1.5.0",
+    "mkdocs-material>=9.5.0",
+]
 
 [build-system]
 requires = ["hatchling"]
@@ -59,4 +63,4 @@ python_files = "test_*.py"
 addopts = "--cov=showstock --cov-report=term --cov-report=xml:coverage.xml"
 
 [tool.hatch.build.targets.wheel]
-packages = ["showstock"] 
+packages = ["showstock"]


### PR DESCRIPTION
## Summary
- document Showstock with MkDocs
- add docs deployment workflow for GitHub Pages
- include docs dependencies

## Testing
- `pre-commit run --files mkdocs.yml docs/index.md pyproject.toml .github/workflows/docs.yml`

------
https://chatgpt.com/codex/tasks/task_e_6868662694408326a52ebacc4c3a6a71