### PR TITLE
Add basic frontend using FastAPI templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,19 @@ cp .env.example .env
 docker compose -f docker/compose.yaml up app db
 ```
 
-The application will be available at http://localhost:8000 by default.
+The API will be available at http://localhost:8000 by default.
+
+### Running the Web Frontend
+
+During development you can launch a lightweight frontend server with
+`uvicorn`:
+
+```bash
+uvicorn web.main:app --reload
+```
+
+This serves a minimal HTML page that renders data from the API using
+Jinja2 templates. By default it listens on http://localhost:8000.
 
 ### Running Tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "asyncpg>=0.27.0",
     "aiosqlite>=0.21.0",
     "python-dotenv>=1.0.0",
+    "jinja2>=3.1.0",
     "python-jose[cryptography]>=3.3.0",
     "passlib[bcrypt]>=1.7.4",
     "python-multipart>=0.0.5",

--- a/web/main.py
+++ b/web/main.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+from fastapi import FastAPI, Depends, Request
+from fastapi.templating import Jinja2Templates
+from fastapi.responses import HTMLResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from showstock.api import get_brands, get_feeds
+from showstock.db import get_db, init_db, close_db
+from showstock.main import app as api_app
+
+
+BASE_DIR = Path(__file__).resolve().parent
+templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+
+app = FastAPI(title="Showstock Web")
+
+# Mount the existing API under /api
+app.mount("/api", api_app)
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    await init_db()
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    await close_db()
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request, db: AsyncSession = Depends(get_db)):
+    brands = await get_brands(db)
+    feeds = await get_feeds(db)
+    return templates.TemplateResponse(
+        "index.html", {"request": request, "brands": brands, "feeds": feeds}
+    )

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Showstock</title>
+</head>
+<body>
+    <h1>Showstock</h1>
+    <h2>Brands</h2>
+    <ul>
+        {% for brand in brands %}
+        <li>{{ brand.name }}</li>
+        {% else %}
+        <li>No brands found.</li>
+        {% endfor %}
+    </ul>
+    <h2>Feeds</h2>
+    <ul>
+        {% for feed in feeds %}
+        <li>{{ feed.name }} ({{ feed.feed_type }})</li>
+        {% else %}
+        <li>No feeds found.</li>
+        {% endfor %}
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build a simple HTML frontend in `web` using FastAPI
- mount existing API under `/api`
- support Jinja2 templates
- document how to run the frontend
- install `jinja2` dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68782e302f28832686c47dde9497d2c4